### PR TITLE
Adding configuration properties to update yaml if Kibana installation is reuired

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=141.0.0
+version=141.0.1
 input.status=snapshot

--- a/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
@@ -274,4 +274,8 @@ public interface IConfiguration
 
     public boolean isSecutrityGroupInMultiDC();
 
+    public boolean isKibanaSetupRequired();
+
+    public int getKibanaPort();
+
 }

--- a/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
@@ -109,6 +109,8 @@ public class RaigadConfiguration implements IConfiguration
     private static final String CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED = MY_WEBAPP_NAME + ".eureka.host.supplier.enabled";
     private static final String CONFIG_COMMA_SEPARATED_CASSANDRA_HOSTNAMES = MY_WEBAPP_NAME + ".comma.separated.cassandra.hostnames";
     private static final String CONFIG_IS_SECURITY_GROUP_IN_MULTI_DC = MY_WEBAPP_NAME + ".security.group.in.multi.dc.enabled";
+    private static final String CONFIG_IS_KIBANA_SETUP_REQUIRED = MY_WEBAPP_NAME + ".kibana.setup.required";
+    private static final String CONFIG_KIBANA_PORT = MY_WEBAPP_NAME + ".kibana.port";
 
 
     // Amazon specific
@@ -203,6 +205,9 @@ public class RaigadConfiguration implements IConfiguration
     private static final boolean DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED = true;
     private static final String DEFAULT_COMMA_SEPARATED_CASSANDRA_HOSTNAMES = "";
     private static final boolean DEFAULT_IS_SECURITY_GROUP_IN_MULTI_DC = false;
+    private static final boolean DEFAULT_IS_KIBANA_SETUP_REQUIRED = false;
+    private static final int DEFAULT_KIBANA_PORT = 8001;
+
 
     private final IConfigSource config; 
     private static final Logger logger = LoggerFactory.getLogger(RaigadConfiguration.class);
@@ -278,6 +283,8 @@ public class RaigadConfiguration implements IConfiguration
     private final DynamicBooleanProperty IS_EUREKA_HOST_SUPPLIER_ENABLED = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED, DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED);
     private final DynamicStringProperty COMMA_SEPARATED_CASSANDRA_HOSTNAMES = DynamicPropertyFactory.getInstance().getStringProperty(CONFIG_COMMA_SEPARATED_CASSANDRA_HOSTNAMES, DEFAULT_COMMA_SEPARATED_CASSANDRA_HOSTNAMES);
     private final DynamicBooleanProperty IS_SECURITY_GROUP_IN_MULTI_DC = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_IS_SECURITY_GROUP_IN_MULTI_DC, DEFAULT_IS_SECURITY_GROUP_IN_MULTI_DC);
+    private final DynamicBooleanProperty IS_KIBANA_SETUP_REQUIRED = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_IS_KIBANA_SETUP_REQUIRED, DEFAULT_IS_KIBANA_SETUP_REQUIRED);
+    private final DynamicIntProperty KIBANA_PORT = DynamicPropertyFactory.getInstance().getIntProperty(CONFIG_KIBANA_PORT, DEFAULT_KIBANA_PORT);
 
 
     @Inject
@@ -812,6 +819,16 @@ public class RaigadConfiguration implements IConfiguration
     @Override
     public boolean isSecutrityGroupInMultiDC() {
         return IS_SECURITY_GROUP_IN_MULTI_DC.get();
+    }
+
+    @Override
+    public boolean isKibanaSetupRequired() {
+        return IS_KIBANA_SETUP_REQUIRED.get();
+    }
+
+    @Override
+    public int getKibanaPort() {
+        return KIBANA_PORT.get();
     }
 
 }

--- a/raigad/src/main/java/com/netflix/raigad/defaultimpl/StandardTuner.java
+++ b/raigad/src/main/java/com/netflix/raigad/defaultimpl/StandardTuner.java
@@ -58,6 +58,12 @@ public class StandardTuner implements IElasticsearchTuner
         map.put("path.logs", config.getLogFileLocation());
         map.put("transport.tcp.port", config.getTransportTcpPort());
 
+        if(config.isKibanaSetupRequired())
+        {
+            map.put("http.cors.enabled",true);
+            map.put("http.cors.allow-origin","http://"+config.getHostname()+":"+config.getKibanaPort());
+        }
+
         if(config.amITribeNode())
         {
             String clusterParams = config.getCommaSeparatedSourceClustersForTribeNode();

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/NodeIndicesStatsMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/NodeIndicesStatsMonitor.java
@@ -95,13 +95,13 @@ public class NodeIndicesStatsMonitor extends Task
             }
             if (ndStat == null) {
                 logger.info("NodeIndicesStats is null,hence returning (No NodeIndicesStats).");
-                resetNodeIndicesStats(nodeIndicesStatsBean);
+                //resetNodeIndicesStats(nodeIndicesStatsBean);
                 return;
             }
             nodeIndicesStats = ndStat.getIndices();
             if (nodeIndicesStats == null) {
                 logger.info("NodeIndicesStats is null,hence returning (No NodeIndicesStats).");
-                resetNodeIndicesStats(nodeIndicesStatsBean);
+                //resetNodeIndicesStats(nodeIndicesStatsBean);
                 return;
             }
 
@@ -122,7 +122,7 @@ public class NodeIndicesStatsMonitor extends Task
         }
         catch(Exception e)
         {
-            resetNodeIndicesStats(nodeIndicesStatsBean);
+            //resetNodeIndicesStats(nodeIndicesStatsBean);
             logger.warn("failed to load Indices stats data", e);
         }
 
@@ -420,12 +420,12 @@ public class NodeIndicesStatsMonitor extends Task
         {
             return nodeIndicesStatsBean.get().indexingDeleteCurrent;
         }
-        @Monitor(name="indexing_index_delta", type=DataSourceType.COUNTER)
+        @Monitor(name="indexing_index_delta", type=DataSourceType.GAUGE)
         public long getIndexingIndexDelta()
         {
             return nodeIndicesStatsBean.get().indexingIndexDelta;
         }
-        @Monitor(name="indexing_delete_delta", type=DataSourceType.COUNTER)
+        @Monitor(name="indexing_delete_delta", type=DataSourceType.GAUGE)
         public long getIndexingDeleteDelta()
         {
             return nodeIndicesStatsBean.get().indexingDeleteDelta;

--- a/raigad/src/test/java/com/netflix/raigad/configuration/FakeConfiguration.java
+++ b/raigad/src/test/java/com/netflix/raigad/configuration/FakeConfiguration.java
@@ -445,4 +445,14 @@ public class FakeConfiguration implements IConfiguration {
         return false;
     }
 
+    @Override
+    public boolean isKibanaSetupRequired() {
+        return false;
+    }
+
+    @Override
+    public int getKibanaPort() {
+        return 0;
+    }
+
 }


### PR DESCRIPTION
ES Version 1.4.1 comes up with new security changes. Due to these changes, Kibana server can not talk to elasticsearch cluster. 

Following changes will fix this issue.

Change also include updating index_*_delta metrics to Gauge instead of Counter.