### PR TITLE
Updating CustomUnicastHostsProvider so that it uses version.minimumCompatibilityVersion()

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=141.0.4
+version=141.0.5
 input.status=snapshot

--- a/raigad-es-extensions/src/main/java/org/elasticsearch/discovery/custom/CustomUnicastHostsProvider.java
+++ b/raigad-es-extensions/src/main/java/org/elasticsearch/discovery/custom/CustomUnicastHostsProvider.java
@@ -54,7 +54,7 @@ public class CustomUnicastHostsProvider extends AbstractComponent implements Uni
 						logger.debug(
 								"adding {}, address {}, transport_address {}",
 								instance.getId(), instance.getHostIP(),addresses[i]);
-						discoNodes.add(new DiscoveryNode(instance.getId(),addresses[i], version));
+						discoNodes.add(new DiscoveryNode(instance.getId(),addresses[i], version.minimumCompatibilityVersion()));
 					}
 				} catch (Exception e) {
 					logger.warn("failed to add {}, address {}", e,instance.getId(), instance.getHostIP());


### PR DESCRIPTION
CustomUnicastHostsProvider creates DiscoveryNodes that are used as an initial seed for unicast based discovery. At the moment it uses Version.CURRENT for those DiscoveryNode object, which confuses the backwards compatibility layer to think this nodes are of the latest version. This causes new nodes to fail to join old nodes as the ping serialization goes wrong. Instead we should use version.minimumCompatibilityVersion().

Reference:https://github.com/elasticsearch/elasticsearch-cloud-aws/pull/145