### PR TITLE
Adding configuration properties and tuning yaml for Multi-region Tribe node support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=132.0.4
+version=132.0.5
 input.status=snapshot

--- a/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
@@ -160,7 +160,9 @@ public interface IConfiguration
      */
     public String getElasticsearchDiscoveryType();
 
-
+    /**
+     * @return Whether it's a Multi-Region Setup
+     */
 	public boolean isMultiDC();
 
     /**
@@ -273,5 +275,10 @@ public interface IConfiguration
     public String getCommaSeparatedCassandraHostNames();
 
     public boolean isSecutrityGroupInMultiDC();
+
+    /**
+     * @return Whether current cluster is Single Region cluster but is a Source Cluster in Multi-Region Tribe Node Setup
+     */
+    public boolean amISourceClusterForTribeNodeInMultiDC();
 
 }

--- a/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
@@ -110,6 +110,7 @@ public class RaigadConfiguration implements IConfiguration
     private static final String CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED = MY_WEBAPP_NAME + ".eureka.host.supplier.enabled";
     private static final String CONFIG_COMMA_SEPARATED_CASSANDRA_HOSTNAMES = MY_WEBAPP_NAME + ".comma.separated.cassandra.hostnames";
     private static final String CONFIG_IS_SECURITY_GROUP_IN_MULTI_DC = MY_WEBAPP_NAME + ".security.group.in.multi.dc.enabled";
+    private static final String CONFIG_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC = MY_WEBAPP_NAME + ".tribe.node.source.cluster.enabled.in.multi.dc";
 
 
     // Amazon specific
@@ -204,6 +205,7 @@ public class RaigadConfiguration implements IConfiguration
     private static final boolean DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED = true;
     private static final String DEFAULT_COMMA_SEPARATED_CASSANDRA_HOSTNAMES = "";
     private static final boolean DEFAULT_IS_SECURITY_GROUP_IN_MULTI_DC = false;
+    private static final boolean DEFAULT_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC = false;
 
     private final IConfigSource config; 
     private static final Logger logger = LoggerFactory.getLogger(RaigadConfiguration.class);
@@ -279,6 +281,7 @@ public class RaigadConfiguration implements IConfiguration
     private final DynamicBooleanProperty IS_EUREKA_HOST_SUPPLIER_ENABLED = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED, isDefaultIsEurekaHostSupplierEnabled());
     private final DynamicStringProperty COMMA_SEPARATED_CASSANDRA_HOSTNAMES = DynamicPropertyFactory.getInstance().getStringProperty(CONFIG_COMMA_SEPARATED_CASSANDRA_HOSTNAMES, getDefaultCommaSeparatedCassandraHostnames());
     private final DynamicBooleanProperty IS_SECURITY_GROUP_IN_MULTI_DC = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_IS_SECURITY_GROUP_IN_MULTI_DC, isDefaultIsSecurityGroupInMultiDc());
+    private final DynamicBooleanProperty AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC, isDefaultAmISourceClusterForTribeNodeInMultiDC());
 
 
     @Inject
@@ -815,6 +818,11 @@ public class RaigadConfiguration implements IConfiguration
         return IS_SECURITY_GROUP_IN_MULTI_DC.get();
     }
 
+    @Override
+    public boolean amISourceClusterForTribeNodeInMultiDC() {
+        return AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC.get();
+    }
+
     public String getDefaultCredentialProvider()
     {
        return config.get(CONFIG_CREDENTIAL_PROVIDER,DEFAULT_CREDENTIAL_PROVIDER);
@@ -1104,6 +1112,10 @@ public class RaigadConfiguration implements IConfiguration
 
     public boolean isDefaultIsSecurityGroupInMultiDc() {
         return config.get(CONFIG_IS_SECURITY_GROUP_IN_MULTI_DC,DEFAULT_IS_SECURITY_GROUP_IN_MULTI_DC);
+    }
+
+    public boolean isDefaultAmISourceClusterForTribeNodeInMultiDC() {
+        return config.get(CONFIG_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC,DEFAULT_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC);
     }
 
 }

--- a/raigad/src/main/java/com/netflix/raigad/defaultimpl/StandardTuner.java
+++ b/raigad/src/main/java/com/netflix/raigad/defaultimpl/StandardTuner.java
@@ -81,6 +81,10 @@ public class StandardTuner implements IElasticsearchTuner
             map.put("node.master", false);
             map.put("node.data", false);
 
+            if (config.isMultiDC()) {
+                map.put("network.publish_host", config.getHostIP());
+            }
+
             if(config.amIWriteEnabledTribeNode())
                 map.put("tribe.blocks.write", false);
             else
@@ -108,7 +112,11 @@ public class StandardTuner implements IElasticsearchTuner
             if (config.isMultiDC()) {
                 map.put("node.rack_id", config.getDC());
                 map.put("network.publish_host", config.getHostIP());
-            } else {
+            } else if (config.amISourceClusterForTribeNodeInMultiDC()) {
+                map.put("node.rack_id", config.getRac());
+                map.put("network.publish_host", config.getHostIP());
+            }
+            else {
                 map.put("node.rack_id", config.getRac());
             }
 


### PR DESCRIPTION
Adding configuration properties and tuning yaml for Multi-region Tribe node support.

These settings can be used in the setup where single region clusters from different regions need to be accessed via Tribe node