### PR TITLE
Adding configuration properties and tuning yaml for Multi-region Tribe node support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=150.0.1
+version=150.0.2
 input.status=snapshot

--- a/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
@@ -160,7 +160,9 @@ public interface IConfiguration
      */
     public String getElasticsearchDiscoveryType();
 
-
+    /**
+     * @return Whether it's a Multi-Region Setup
+     */
 	public boolean isMultiDC();
 
     /**
@@ -277,5 +279,10 @@ public interface IConfiguration
     public boolean isKibanaSetupRequired();
 
     public int getKibanaPort();
+
+    /**
+     * @return Whether current cluster is Single Region cluster but is a Source Cluster in Multi-Region Tribe Node Setup
+     */
+    public boolean amISourceClusterForTribeNodeInMultiDC();
 
 }

--- a/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
@@ -112,6 +112,7 @@ public class RaigadConfiguration implements IConfiguration
     private static final String CONFIG_IS_SECURITY_GROUP_IN_MULTI_DC = MY_WEBAPP_NAME + ".security.group.in.multi.dc.enabled";
     private static final String CONFIG_IS_KIBANA_SETUP_REQUIRED = MY_WEBAPP_NAME + ".kibana.setup.required";
     private static final String CONFIG_KIBANA_PORT = MY_WEBAPP_NAME + ".kibana.port";
+    private static final String CONFIG_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC = MY_WEBAPP_NAME + ".tribe.node.source.cluster.enabled.in.multi.dc";
 
 
     // Amazon specific
@@ -208,7 +209,7 @@ public class RaigadConfiguration implements IConfiguration
     private static final boolean DEFAULT_IS_SECURITY_GROUP_IN_MULTI_DC = false;
     private static final boolean DEFAULT_IS_KIBANA_SETUP_REQUIRED = false;
     private static final int DEFAULT_KIBANA_PORT = 8001;
-
+    private static final boolean DEFAULT_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC = false;
 
     private final IConfigSource config; 
     private static final Logger logger = LoggerFactory.getLogger(RaigadConfiguration.class);
@@ -286,6 +287,7 @@ public class RaigadConfiguration implements IConfiguration
     private final DynamicBooleanProperty IS_SECURITY_GROUP_IN_MULTI_DC = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_IS_SECURITY_GROUP_IN_MULTI_DC, isDefaultIsSecurityGroupInMultiDc());
     private final DynamicBooleanProperty IS_KIBANA_SETUP_REQUIRED = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_IS_KIBANA_SETUP_REQUIRED, isDefaultIsKibanaSetupRequired());
     private final DynamicIntProperty KIBANA_PORT = DynamicPropertyFactory.getInstance().getIntProperty(CONFIG_KIBANA_PORT, getDefaultKibanaPort());
+    private final DynamicBooleanProperty AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC, isDefaultAmISourceClusterForTribeNodeInMultiDC());
 
 
     @Inject
@@ -832,6 +834,11 @@ public class RaigadConfiguration implements IConfiguration
         return KIBANA_PORT.get();
     }
 
+    @Override
+    public boolean amISourceClusterForTribeNodeInMultiDC() {
+        return AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC.get();
+    }
+
     public String getDefaultCredentialProvider()
     {
        return config.get(CONFIG_CREDENTIAL_PROVIDER,DEFAULT_CREDENTIAL_PROVIDER);
@@ -1129,5 +1136,9 @@ public class RaigadConfiguration implements IConfiguration
 
     public boolean isDefaultIsKibanaSetupRequired() {
         return config.get(CONFIG_IS_KIBANA_SETUP_REQUIRED,DEFAULT_IS_KIBANA_SETUP_REQUIRED);
+    }
+
+    public boolean isDefaultAmISourceClusterForTribeNodeInMultiDC() {
+        return config.get(CONFIG_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC,DEFAULT_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC);
     }
 }

--- a/raigad/src/main/java/com/netflix/raigad/defaultimpl/StandardTuner.java
+++ b/raigad/src/main/java/com/netflix/raigad/defaultimpl/StandardTuner.java
@@ -87,6 +87,10 @@ public class StandardTuner implements IElasticsearchTuner
             map.put("node.master", false);
             map.put("node.data", false);
 
+            if (config.isMultiDC()) {
+                map.put("network.publish_host", config.getHostIP());
+            }
+
             if(config.amIWriteEnabledTribeNode())
                 map.put("tribe.blocks.write", false);
             else
@@ -114,7 +118,11 @@ public class StandardTuner implements IElasticsearchTuner
             if (config.isMultiDC()) {
                 map.put("node.rack_id", config.getDC());
                 map.put("network.publish_host", config.getHostIP());
-            } else {
+            } else if (config.amISourceClusterForTribeNodeInMultiDC()) {
+                map.put("node.rack_id", config.getRac());
+                map.put("network.publish_host", config.getHostIP());
+            }
+            else {
                 map.put("node.rack_id", config.getRac());
             }
 


### PR DESCRIPTION
Adding configuration properties and tuning yaml for Multi-region Tribe node support.

These settings can be used in the setup where single region clusters from different regions need to be accessed via Tribe node