### PR TITLE
Add the ability to report cluster-metrics only from the master-node

### DIFF
--- a/raigad/src/main/java/com/netflix/raigad/backup/RestoreBackupManager.java
+++ b/raigad/src/main/java/com/netflix/raigad/backup/RestoreBackupManager.java
@@ -65,7 +65,7 @@ public class RestoreBackupManager extends Task
             if (EsUtils.amIMasterNode(config,httpModule))
             {
                 // If Elasticsearch is started then only start Snapshot Backup
-                if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+                if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
                     String exceptionMsg = "Elasticsearch is not yet started, hence not Starting Restore Operation";
                     logger.info(exceptionMsg);
                     return;

--- a/raigad/src/main/java/com/netflix/raigad/backup/SnapshotBackupManager.java
+++ b/raigad/src/main/java/com/netflix/raigad/backup/SnapshotBackupManager.java
@@ -71,7 +71,7 @@ public class SnapshotBackupManager extends Task
             if (EsUtils.amIMasterNode(config,httpModule))
             {
                 // If Elasticsearch is started then only start Snapshot Backup
-                if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+                if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
                     String exceptionMsg = "Elasticsearch is not yet started, hence not Starting Snapshot Operation";
                     logger.info(exceptionMsg);
                     return;

--- a/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
@@ -41,7 +41,7 @@ public interface IConfiguration
     public String getElasticsearchStartupScript();
 
     /**
-     * @return Path to Elasticsearch stop sript
+     * @return Path to Elasticsearch stop script
      */
     public String getElasticsearchStopScript();
    

--- a/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
@@ -285,4 +285,6 @@ public interface IConfiguration
      */
     public boolean amISourceClusterForTribeNodeInMultiDC();
 
+    public boolean reportMetricsFromMasterOnly();
+
 }

--- a/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
@@ -113,6 +113,8 @@ public class RaigadConfiguration implements IConfiguration
     private static final String CONFIG_IS_KIBANA_SETUP_REQUIRED = MY_WEBAPP_NAME + ".kibana.setup.required";
     private static final String CONFIG_KIBANA_PORT = MY_WEBAPP_NAME + ".kibana.port";
     private static final String CONFIG_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC = MY_WEBAPP_NAME + ".tribe.node.source.cluster.enabled.in.multi.dc";
+    private static final String CONFIG_REPORT_METRICS_FROM_MASTER_ONLY = MY_WEBAPP_NAME + ".report.metrics.from.master.only";
+
 
 
     // Amazon specific
@@ -210,6 +212,7 @@ public class RaigadConfiguration implements IConfiguration
     private static final boolean DEFAULT_IS_KIBANA_SETUP_REQUIRED = false;
     private static final int DEFAULT_KIBANA_PORT = 8001;
     private static final boolean DEFAULT_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC = false;
+    private static final boolean DEFAULT_REPORT_METRICS_FROM_MASTER_ONLY = false;
 
     private final IConfigSource config; 
     private static final Logger logger = LoggerFactory.getLogger(RaigadConfiguration.class);
@@ -288,6 +291,7 @@ public class RaigadConfiguration implements IConfiguration
     private final DynamicBooleanProperty IS_KIBANA_SETUP_REQUIRED = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_IS_KIBANA_SETUP_REQUIRED, isDefaultIsKibanaSetupRequired());
     private final DynamicIntProperty KIBANA_PORT = DynamicPropertyFactory.getInstance().getIntProperty(CONFIG_KIBANA_PORT, getDefaultKibanaPort());
     private final DynamicBooleanProperty AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC, isDefaultAmISourceClusterForTribeNodeInMultiDC());
+    private final DynamicBooleanProperty REPORT_METRICS_FROM_MASTER_ONLY = DynamicPropertyFactory.getInstance().getBooleanProperty(CONFIG_REPORT_METRICS_FROM_MASTER_ONLY, getDefaultReportMetricsFromMasterOnly());
 
 
     @Inject
@@ -839,6 +843,11 @@ public class RaigadConfiguration implements IConfiguration
         return AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC.get();
     }
 
+    @Override
+    public boolean reportMetricsFromMasterOnly() {
+        return REPORT_METRICS_FROM_MASTER_ONLY.get();
+    }
+
     public String getDefaultCredentialProvider()
     {
        return config.get(CONFIG_CREDENTIAL_PROVIDER,DEFAULT_CREDENTIAL_PROVIDER);
@@ -1140,5 +1149,9 @@ public class RaigadConfiguration implements IConfiguration
 
     public boolean isDefaultAmISourceClusterForTribeNodeInMultiDC() {
         return config.get(CONFIG_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC,DEFAULT_AM_I_SOURCE_CLUSTER_FOR_TRIBE_NODE_IN_MULTI_DC);
+    }
+
+    public boolean getDefaultReportMetricsFromMasterOnly() {
+        return config.get(CONFIG_REPORT_METRICS_FROM_MASTER_ONLY,DEFAULT_REPORT_METRICS_FROM_MASTER_ONLY);
     }
 }

--- a/raigad/src/main/java/com/netflix/raigad/defaultimpl/ElasticSearchShardAllocationManager.java
+++ b/raigad/src/main/java/com/netflix/raigad/defaultimpl/ElasticSearchShardAllocationManager.java
@@ -75,7 +75,7 @@ public class ElasticSearchShardAllocationManager {
             {
                 logger.info("Running ElasticSearchShardAllocationManager task ...");
                 // If Elasticsearch is started then only start the shard allocation
-                if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+                if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
                     String exceptionMsg = "Elasticsearch is not yet started, check back again later";
                     logger.info(exceptionMsg);
                     return;

--- a/raigad/src/main/java/com/netflix/raigad/indexmanagement/ElasticSearchIndexManager.java
+++ b/raigad/src/main/java/com/netflix/raigad/indexmanagement/ElasticSearchIndexManager.java
@@ -82,7 +82,7 @@ public class ElasticSearchIndexManager extends Task {
             if (EsUtils.amIMasterNode(config, httpModule))
             {
                 // If Elasticsearch is started then only start Snapshot Backup
-                if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+                if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
                     String exceptionMsg = "Elasticsearch is not yet started, hence not Starting Index Management Operation";
                     logger.info(exceptionMsg);
                     return;

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/AllCircuitBreakerStatsMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/AllCircuitBreakerStatsMonitor.java
@@ -55,7 +55,7 @@ public class AllCircuitBreakerStatsMonitor extends Task
 	public void execute() throws Exception {
 
 		// If Elasticsearch is started then only start the monitoring
-		if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+		if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
 			String exceptionMsg = "Elasticsearch is not yet started, check back again later";
 			logger.info(exceptionMsg);
 			return;

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/FsStatsMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/FsStatsMonitor.java
@@ -53,7 +53,7 @@ public class FsStatsMonitor extends Task
 	public void execute() throws Exception {
 
 		// If Elasticsearch is started then only start the monitoring
-		if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+		if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
 			String exceptionMsg = "Elasticsearch is not yet started, check back again later";
 			logger.info(exceptionMsg);
 			return;

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/HealthMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/HealthMonitor.java
@@ -65,9 +65,9 @@ public class HealthMonitor extends Task
     @Override
     public void execute() throws Exception {
 
-        // If Elasticsearch is started then only start the monitoring
-        if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
-            String exceptionMsg = "Elasticsearch is not yet started, check back again later";
+        // report cluster-metrics only if Elasticsearch process is running
+        if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
+            String exceptionMsg = "Elasticsearch is not running, check back again later";
             logger.info(exceptionMsg);
             return;
         }

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/HealthMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/HealthMonitor.java
@@ -74,7 +74,7 @@ public class HealthMonitor extends Task
 
         // In case we configured only the Master-node to report metrics
         // and this node is not a master - bail out
-        if (config.reportMetricsFromMasterOnly() && EsUtils.amIMasterNode(config, httpModule)) {
+        if (config.reportMetricsFromMasterOnly() && !EsUtils.amIMasterNode(config, httpModule)) {
             return;
         }
 

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/HttpStatsMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/HttpStatsMonitor.java
@@ -53,7 +53,7 @@ public class HttpStatsMonitor extends Task
 	public void execute() throws Exception {
 
 		// If Elasticsearch is started then only start the monitoring
-		if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+		if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
 			String exceptionMsg = "Elasticsearch is not yet started, check back again later";
 			logger.info(exceptionMsg);
 			return;

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/JvmStatsMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/JvmStatsMonitor.java
@@ -57,7 +57,7 @@ public class JvmStatsMonitor extends Task
 	public void execute() throws Exception {
 
 		// If Elasticsearch is started then only start the monitoring
-		if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+		if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
 			String exceptionMsg = "Elasticsearch is not yet started, check back again later";
 			logger.info(exceptionMsg);
 			return;

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/NetworkStatsMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/NetworkStatsMonitor.java
@@ -53,7 +53,7 @@ public class NetworkStatsMonitor extends Task
 	public void execute() throws Exception {
 
 		// If Elasticsearch is started then only start the monitoring
-		if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+		if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
 			String exceptionMsg = "Elasticsearch is not yet started, check back again later";
 			logger.info(exceptionMsg);
 			return;

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/NodeHealthMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/NodeHealthMonitor.java
@@ -58,10 +58,10 @@ public class NodeHealthMonitor extends Task {
 
         HealthBean healthBean = new HealthBean();
         try {
-            healthBean.esprocessdown = 0;
+            healthBean.esprocessrunning = 0;
             if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
                 logger.info("Elasticsearch process is up & running");
-                healthBean.esprocessdown = 1;
+                healthBean.esprocessrunning = 1;
             }
         } catch (Exception e) {
             resetHealthStats(healthBean);
@@ -80,12 +80,12 @@ public class NodeHealthMonitor extends Task {
 
         @Monitor(name = "es_isesprocessdown", type = DataSourceType.GAUGE)
         public int getIsEsProcessDown() {
-            return healthBean.get().esprocessdown;
+            return healthBean.get().esprocessrunning;
         }
     }
 
     private static class HealthBean {
-        private int esprocessdown = -1;
+        private int esprocessrunning = -1;
     }
 
     @Override
@@ -99,7 +99,7 @@ public class NodeHealthMonitor extends Task {
     }
 
     private void resetHealthStats(HealthBean healthBean) {
-        healthBean.esprocessdown = -1;
+        healthBean.esprocessrunning = -1;
     }
 }
 

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/NodeHealthMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/NodeHealthMonitor.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.raigad.monitoring;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.netflix.raigad.configuration.IConfiguration;
+import com.netflix.raigad.scheduler.SimpleTimer;
+import com.netflix.raigad.scheduler.Task;
+import com.netflix.raigad.scheduler.TaskTimer;
+import com.netflix.raigad.utils.ElasticsearchProcessMonitor;
+import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.annotations.Monitor;
+import com.netflix.servo.monitor.Monitors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Created by alfasi on 4/22/15.
+ */
+@Singleton
+public class NodeHealthMonitor extends Task {
+    private static final Logger logger = LoggerFactory.getLogger(NodeHealthMonitor.class);
+    public static final String METRIC_NAME = "Elasticsearch_NodeHealthMonitor";
+    private final ElasticsearchNodeHealthReporter healthReporter;
+
+    @Inject
+    public NodeHealthMonitor(IConfiguration config) {
+        super(config);
+        healthReporter = new ElasticsearchNodeHealthReporter();
+        Monitors.registerObject(healthReporter);
+    }
+
+    @Override
+    public void execute() throws Exception {
+
+        // If Elasticsearch is started then only start the monitoring
+        if (!ElasticsearchProcessMonitor.getWasElasticsearchStarted()) {
+            String exceptionMsg = "Elasticsearch is not yet started, check back again later";
+            logger.info(exceptionMsg);
+            return;
+        }
+
+        HealthBean healthBean = new HealthBean();
+        try {
+            healthBean.esprocessdown = 0;
+            if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
+                healthBean.esprocessdown = 1;
+            }
+        } catch (Exception e) {
+            resetHealthStats(healthBean);
+            logger.warn("failed to check if Elasticsearch process is running", e);
+        }
+
+        healthReporter.healthBean.set(healthBean);
+    }
+
+    public class ElasticsearchNodeHealthReporter {
+        private final AtomicReference<HealthBean> healthBean;
+
+        public ElasticsearchNodeHealthReporter() {
+            healthBean = new AtomicReference<HealthBean>(new HealthBean());
+        }
+
+        @Monitor(name = "es_isesprocessdown", type = DataSourceType.GAUGE)
+        public int getIsEsProcessDown() {
+            return healthBean.get().esprocessdown;
+        }
+    }
+
+    private static class HealthBean {
+        private int esprocessdown = -1;
+    }
+
+    @Override
+    public String getName() {
+        return METRIC_NAME;
+    }
+
+    public static TaskTimer getTimer(String name)
+    {
+        return new SimpleTimer(name, 60 * 1000);
+    }
+
+    private void resetHealthStats(HealthBean healthBean) {
+        healthBean.esprocessdown = -1;
+    }
+}
+
+

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/NodeHealthMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/NodeHealthMonitor.java
@@ -60,6 +60,7 @@ public class NodeHealthMonitor extends Task {
         try {
             healthBean.esprocessdown = 0;
             if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
+                logger.info("Elasticsearch process is up & running");
                 healthBean.esprocessdown = 1;
             }
         } catch (Exception e) {

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/NodeIndicesStatsMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/NodeIndicesStatsMonitor.java
@@ -92,7 +92,7 @@ public class NodeIndicesStatsMonitor extends Task
     public void execute() throws Exception {
 
         // If Elasticsearch is started then only start the monitoring
-        if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+        if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
             String exceptionMsg = "Elasticsearch is not yet started, check back again later";
             logger.info(exceptionMsg);
             return;

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/OsStatsMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/OsStatsMonitor.java
@@ -53,7 +53,7 @@ public class OsStatsMonitor extends Task
 	public void execute() throws Exception {
 
 		// If Elasticsearch is started then only start the monitoring
-		if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+		if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
 			String exceptionMsg = "Elasticsearch is not yet started, check back again later";
 			logger.info(exceptionMsg);
 			return;

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/ProcessStatsMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/ProcessStatsMonitor.java
@@ -53,7 +53,7 @@ public class ProcessStatsMonitor extends Task
 	public void execute() throws Exception {
 
 		// If Elasticsearch is started then only start the monitoring
-		if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+		if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
 			String exceptionMsg = "Elasticsearch is not yet started, check back again later";
 			logger.info(exceptionMsg);
 			return;

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/SnapshotBackupMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/SnapshotBackupMonitor.java
@@ -53,7 +53,7 @@ public class SnapshotBackupMonitor extends Task
     public void execute() throws Exception {
 
         // If Elasticsearch is started then only start the monitoring
-        if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+        if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
             String exceptionMsg = "Elasticsearch is not yet started, check back again later";
             logger.info(exceptionMsg);
             return;

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/ThreadPoolStatsMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/ThreadPoolStatsMonitor.java
@@ -54,7 +54,7 @@ public class ThreadPoolStatsMonitor extends Task
 	public void execute() throws Exception {
 
 		// If Elasticsearch is started then only start the monitoring
-		if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+		if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
 			String exceptionMsg = "Elasticsearch is not yet started, check back again later";
 			logger.info(exceptionMsg);
 			return;

--- a/raigad/src/main/java/com/netflix/raigad/monitoring/TransportStatsMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/monitoring/TransportStatsMonitor.java
@@ -53,7 +53,7 @@ public class TransportStatsMonitor extends Task
 	public void execute() throws Exception {
 
 		// If Elasticsearch is started then only start the monitoring
-		if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+		if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
 			String exceptionMsg = "Elasticsearch is not yet started, check back again later";
 			logger.info(exceptionMsg);
 			return;

--- a/raigad/src/main/java/com/netflix/raigad/resources/NodeHealthCheck.java
+++ b/raigad/src/main/java/com/netflix/raigad/resources/NodeHealthCheck.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.raigad.resources;
+
+import com.netflix.raigad.utils.ElasticsearchProcessMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Created by alfasi on 4/23/15.
+ */
+@Path("/v1/healthcheck")
+@Produces(MediaType.APPLICATION_JSON)
+public class NodeHealthCheck {
+
+    private static final Logger logger = LoggerFactory.getLogger(NodeHealthCheck.class);
+    private static final String REST_SUCCESS = "[\"ok\"]";
+
+    @GET
+    @Path("/")
+    public Response checkHealth()
+    {
+        logger.info("Got REST call to check Node-health...");
+        if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
+            return Response.serverError().status(500).build();
+        }
+        return Response.ok(REST_SUCCESS, MediaType.APPLICATION_JSON).build();
+    }
+
+}

--- a/raigad/src/main/java/com/netflix/raigad/resources/NodeHealthCheck.java
+++ b/raigad/src/main/java/com/netflix/raigad/resources/NodeHealthCheck.java
@@ -35,7 +35,7 @@ public class NodeHealthCheck {
     private static final String REST_SUCCESS = "[\"ok\"]";
 
     @GET
-    @Path("/")
+    @Path("/isesprocessrunning")
     public Response checkHealth()
     {
         logger.info("Got REST call to check Node-health...");

--- a/raigad/src/main/java/com/netflix/raigad/startup/RaigadServer.java
+++ b/raigad/src/main/java/com/netflix/raigad/startup/RaigadServer.java
@@ -132,12 +132,17 @@ public class RaigadServer
                 scheduler.addTaskWithDelay(SnapshotBackupManager.JOBNAME, SnapshotBackupManager.class, SnapshotBackupManager.getTimer(config), ES_SNAPSHOT_INITIAL_DELAY);
                 // Run Index Management task only on Master Nodes
                 scheduler.addTaskWithDelay(ElasticSearchIndexManager.JOBNAME, ElasticSearchIndexManager.class, ElasticSearchIndexManager.getTimer(config), config.getAutoCreateIndexInitialStartDelaySeconds());
+                scheduler.addTaskWithDelay(HealthMonitor.METRIC_NAME, HealthMonitor.class, HealthMonitor.getTimer("HealthMonitor"),ES_HEALTH_MONITOR_DELAY);
+            }
+            else if (!config.reportMetricsFromMasterOnly()) {
+                scheduler.addTaskWithDelay(HealthMonitor.METRIC_NAME, HealthMonitor.class, HealthMonitor.getTimer("HealthMonitor"),ES_HEALTH_MONITOR_DELAY);
             }
         }
         else
         {
             scheduler.addTaskWithDelay(SnapshotBackupManager.JOBNAME, SnapshotBackupManager.class, SnapshotBackupManager.getTimer(config), ES_SNAPSHOT_INITIAL_DELAY);
             scheduler.addTaskWithDelay(ElasticSearchIndexManager.JOBNAME, ElasticSearchIndexManager.class, ElasticSearchIndexManager.getTimer(config), config.getAutoCreateIndexInitialStartDelaySeconds());
+            scheduler.addTaskWithDelay(HealthMonitor.METRIC_NAME, HealthMonitor.class, HealthMonitor.getTimer("HealthMonitor"),ES_HEALTH_MONITOR_DELAY);
         }
 
         /*
@@ -154,7 +159,6 @@ public class RaigadServer
         scheduler.addTask(HttpStatsMonitor.METRIC_NAME, HttpStatsMonitor.class, HttpStatsMonitor.getTimer("HttpStatsMonitor"));
         scheduler.addTask(AllCircuitBreakerStatsMonitor.METRIC_NAME, AllCircuitBreakerStatsMonitor.class, AllCircuitBreakerStatsMonitor.getTimer("AllCircuitBreakerStatsMonitor"));
         scheduler.addTask(SnapshotBackupMonitor.METRIC_NAME, SnapshotBackupMonitor.class, SnapshotBackupMonitor.getTimer("SnapshotBackupMonitor"));
-        scheduler.addTaskWithDelay(HealthMonitor.METRIC_NAME, HealthMonitor.class, HealthMonitor.getTimer("HealthMonitor"),ES_HEALTH_MONITOR_DELAY);
         scheduler.addTaskWithDelay(NodeHealthMonitor.METRIC_NAME, NodeHealthMonitor.class, NodeHealthMonitor.getTimer("NodeHealthMonitor"),ES_NODE_HEALTH_MONITOR_DELAY);
 
     }

--- a/raigad/src/main/java/com/netflix/raigad/startup/RaigadServer.java
+++ b/raigad/src/main/java/com/netflix/raigad/startup/RaigadServer.java
@@ -52,6 +52,7 @@ public class RaigadServer
     private static final int ES_MONITORING_INITIAL_DELAY = 10;
     private static final int ES_SNAPSHOT_INITIAL_DELAY = 100;
     private static final int ES_HEALTH_MONITOR_DELAY = 600;
+    private static final int ES_NODE_HEALTH_MONITOR_DELAY = 10;
     private static final Logger logger = LoggerFactory.getLogger(RaigadServer.class);
 
 
@@ -154,7 +155,7 @@ public class RaigadServer
         scheduler.addTask(AllCircuitBreakerStatsMonitor.METRIC_NAME, AllCircuitBreakerStatsMonitor.class, AllCircuitBreakerStatsMonitor.getTimer("AllCircuitBreakerStatsMonitor"));
         scheduler.addTask(SnapshotBackupMonitor.METRIC_NAME, SnapshotBackupMonitor.class, SnapshotBackupMonitor.getTimer("SnapshotBackupMonitor"));
         scheduler.addTaskWithDelay(HealthMonitor.METRIC_NAME, HealthMonitor.class, HealthMonitor.getTimer("HealthMonitor"),ES_HEALTH_MONITOR_DELAY);
-        scheduler.addTaskWithDelay(NodeHealthMonitor.METRIC_NAME, NodeHealthMonitor.class, NodeHealthMonitor.getTimer("NodeHealthMonitor"),ES_HEALTH_MONITOR_DELAY);
+        scheduler.addTaskWithDelay(NodeHealthMonitor.METRIC_NAME, NodeHealthMonitor.class, NodeHealthMonitor.getTimer("NodeHealthMonitor"),ES_NODE_HEALTH_MONITOR_DELAY);
 
     }
 

--- a/raigad/src/main/java/com/netflix/raigad/startup/RaigadServer.java
+++ b/raigad/src/main/java/com/netflix/raigad/startup/RaigadServer.java
@@ -154,6 +154,7 @@ public class RaigadServer
         scheduler.addTask(AllCircuitBreakerStatsMonitor.METRIC_NAME, AllCircuitBreakerStatsMonitor.class, AllCircuitBreakerStatsMonitor.getTimer("AllCircuitBreakerStatsMonitor"));
         scheduler.addTask(SnapshotBackupMonitor.METRIC_NAME, SnapshotBackupMonitor.class, SnapshotBackupMonitor.getTimer("SnapshotBackupMonitor"));
         scheduler.addTaskWithDelay(HealthMonitor.METRIC_NAME, HealthMonitor.class, HealthMonitor.getTimer("HealthMonitor"),ES_HEALTH_MONITOR_DELAY);
+        scheduler.addTaskWithDelay(NodeHealthMonitor.METRIC_NAME, NodeHealthMonitor.class, NodeHealthMonitor.getTimer("NodeHealthMonitor"),ES_HEALTH_MONITOR_DELAY);
 
     }
 

--- a/raigad/src/main/java/com/netflix/raigad/utils/ESTransportClient.java
+++ b/raigad/src/main/java/com/netflix/raigad/utils/ESTransportClient.java
@@ -99,7 +99,7 @@ public class ESTransportClient
     		ESTransportClient ESTransportClient = null;
     		
 		// If Elasticsearch is started then only start the monitoring
-		if (!ElasticsearchProcessMonitor.isElasticsearchStarted()) {
+		if (!ElasticsearchProcessMonitor.isElasticsearchRunning()) {
 			String exceptionMsg = "Elasticsearch is not yet started, check back again later";
 			//TODO: Change logger to debug
 			logger.info(exceptionMsg);

--- a/raigad/src/main/java/com/netflix/raigad/utils/ElasticsearchProcessMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/utils/ElasticsearchProcessMonitor.java
@@ -37,7 +37,7 @@ public class ElasticsearchProcessMonitor extends Task{
 
 	public static final String JOBNAME = "ES_MONITOR_THREAD";
     private static final Logger logger = LoggerFactory.getLogger(ElasticsearchProcessMonitor.class);
-    private static final AtomicBoolean isElasticsearchRunning = new AtomicBoolean(false);
+    private static final AtomicBoolean isElasticsearchRunningNow = new AtomicBoolean(false);
     private static final AtomicBoolean wasElasticsearchStarted = new AtomicBoolean(false);
 
     @Inject
@@ -56,20 +56,20 @@ public class ElasticsearchProcessMonitor extends Task{
             String line = input.readLine();
         		if (line != null && !isElasticsearchRunning())
         		{
-        			isElasticsearchRunning.set(true);
+        			isElasticsearchRunningNow.set(true);
                     if (! wasElasticsearchStarted.get()) {
                         wasElasticsearchStarted.set(true);
                     }
         		}
         		else if(line  == null && isElasticsearchRunning())
         		{
-        			isElasticsearchRunning.set(false);
+        			isElasticsearchRunningNow.set(false);
         		}
         }
         catch(Exception e)
         {
         	logger.warn("Exception thrown while checking if Elasticsearch is running or not ", e);
-            isElasticsearchRunning.set(false);
+            isElasticsearchRunningNow.set(false);
         }
 		
 	}
@@ -87,7 +87,7 @@ public class ElasticsearchProcessMonitor extends Task{
 
     public static Boolean isElasticsearchRunning()
     {
-        return isElasticsearchRunning.get();
+        return isElasticsearchRunningNow.get();
     }
 
     public static Boolean getWasElasticsearchStarted() {
@@ -97,6 +97,6 @@ public class ElasticsearchProcessMonitor extends Task{
     //Added for testing only
     public static void setElasticsearchStarted()
     {
-		isElasticsearchRunning.set(true);
+		isElasticsearchRunningNow.set(true);
 	}
 }

--- a/raigad/src/main/java/com/netflix/raigad/utils/ElasticsearchProcessMonitor.java
+++ b/raigad/src/main/java/com/netflix/raigad/utils/ElasticsearchProcessMonitor.java
@@ -37,7 +37,8 @@ public class ElasticsearchProcessMonitor extends Task{
 
 	public static final String JOBNAME = "ES_MONITOR_THREAD";
     private static final Logger logger = LoggerFactory.getLogger(ElasticsearchProcessMonitor.class);
-    private static final AtomicBoolean isElasticsearchStarted = new AtomicBoolean(false);
+    private static final AtomicBoolean isElasticsearchRunning = new AtomicBoolean(false);
+    private static final AtomicBoolean wasElasticsearchStarted = new AtomicBoolean(false);
 
     @Inject
     protected ElasticsearchProcessMonitor(IConfiguration config) {
@@ -53,19 +54,22 @@ public class ElasticsearchProcessMonitor extends Task{
         		Process p = Runtime.getRuntime().exec("pgrep -f " + config.getElasticsearchProcessName());
         		BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()));
             String line = input.readLine();
-        		if (line != null&& !isElasticsearchStarted())
+        		if (line != null && !isElasticsearchRunning())
         		{
-        			isElasticsearchStarted.set(true);
+        			isElasticsearchRunning.set(true);
+                    if (! wasElasticsearchStarted.get()) {
+                        wasElasticsearchStarted.set(true);
+                    }
         		}
-        		else if(line  == null&& isElasticsearchStarted())
+        		else if(line  == null && isElasticsearchRunning())
         		{
-        			isElasticsearchStarted.set(false);
+        			isElasticsearchRunning.set(false);
         		}
         }
         catch(Exception e)
         {
         	logger.warn("Exception thrown while checking if Elasticsearch is running or not ", e);
-            isElasticsearchStarted.set(false);
+            isElasticsearchRunning.set(false);
         }
 		
 	}
@@ -81,14 +85,18 @@ public class ElasticsearchProcessMonitor extends Task{
         return JOBNAME;
     }
 
-    public static Boolean isElasticsearchStarted()
+    public static Boolean isElasticsearchRunning()
     {
-        return isElasticsearchStarted.get();
+        return isElasticsearchRunning.get();
+    }
+
+    public static Boolean getWasElasticsearchStarted() {
+        return wasElasticsearchStarted.get();
     }
 
     //Added for testing only
     public static void setElasticsearchStarted()
     {
-		isElasticsearchStarted.set(true);
+		isElasticsearchRunning.set(true);
 	}
 }

--- a/raigad/src/test/java/com/netflix/raigad/configuration/FakeConfiguration.java
+++ b/raigad/src/test/java/com/netflix/raigad/configuration/FakeConfiguration.java
@@ -459,4 +459,9 @@ public class FakeConfiguration implements IConfiguration {
         return false;
     }
 
+    @Override
+    public boolean reportMetricsFromMasterOnly() {
+        return false;
+    }
+
 }


### PR DESCRIPTION
After our discussion I decided to split the implementation into two PRs:

1. This one: which adds the ability to report cluster-related metrics from the master-node only, in order to avoid multiple reports of the same metric. 
This PR leaves the current behavior as default, and in order to activate this new-behavior, the configuration should have the property: 
Raigad.report.metrics.from.master.only=true

2. The next PR that I'll submit will have the additional logic for Node-Healthcheck (reports the metric: "is-elasticsearch-process-running" and has an additional endpoint-url that responds to REST calls with this value as well).