### PR TITLE
Fixing discovery for TribeNodes when deployed in multi region environment

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-release.version=150.0.4-SNAPSHOT
+release.version=150.0.5-SNAPSHOT

--- a/raigad/src/main/java/com/netflix/raigad/identity/InstanceDataDAOCassandra.java
+++ b/raigad/src/main/java/com/netflix/raigad/identity/InstanceDataDAOCassandra.java
@@ -149,7 +149,10 @@ public class InstanceDataDAOCassandra
             if(config.isMultiDC())
             {
                 selectClause  = String.format("SELECT * FROM %s WHERE %s = '%s' ", CF_NAME_INSTANCES, CN_CLUSTER, cluster);
-            }else {
+            }else if (config.amISourceClusterForTribeNodeInMultiDC()) {
+                selectClause  = String.format("SELECT * FROM %s WHERE %s = '%s' ", CF_NAME_INSTANCES, CN_CLUSTER, cluster);
+            }
+            else {
                 selectClause  = String.format("SELECT * FROM %s WHERE %s = '%s' AND %s = '%s' ", CF_NAME_INSTANCES, CN_CLUSTER, cluster, CN_LOCATION, config.getDC());
             }
 

--- a/raigad/src/main/java/com/netflix/raigad/identity/InstanceDataDAOCassandra.java
+++ b/raigad/src/main/java/com/netflix/raigad/identity/InstanceDataDAOCassandra.java
@@ -146,10 +146,8 @@ public class InstanceDataDAOCassandra
         try {
 
             String selectClause = "";
-            if(config.isMultiDC())
+            if(config.isMultiDC() || config.amISourceClusterForTribeNodeInMultiDC())
             {
-                selectClause  = String.format("SELECT * FROM %s WHERE %s = '%s' ", CF_NAME_INSTANCES, CN_CLUSTER, cluster);
-            }else if (config.amISourceClusterForTribeNodeInMultiDC()) {
                 selectClause  = String.format("SELECT * FROM %s WHERE %s = '%s' ", CF_NAME_INSTANCES, CN_CLUSTER, cluster);
             }
             else {


### PR DESCRIPTION
If Tribe Clusters are deployed in different regions then cluster information needs to be queried without region filter.