### PR TITLE
Updating TransportClient which is used mainly for accessing cluster stats

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-release.version=152.0.2-SNAPSHOT
+release.version=152.0.3-SNAPSHOT

--- a/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
@@ -292,4 +292,6 @@ public interface IConfiguration
      * @return tribe id
      */
     public String getTribePreferredClusterIdOnConflict();
+
+    public String getEsNodeName();
 }

--- a/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
@@ -128,6 +128,7 @@ public class RaigadConfiguration implements IConfiguration
     private static final String LOCAL_IP = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/local-ipv4").trim();
     private static final String INSTANCE_ID = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/instance-id").trim();
     private static final String INSTANCE_TYPE = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/instance-type").trim();
+    private static final String ES_NODE_NAME = RAC + "." + INSTANCE_ID;
 
     private static String ASG_NAME = System.getenv("ASG_NAME");
     private static String REGION = System.getenv("EC2_REGION");
@@ -851,6 +852,11 @@ public class RaigadConfiguration implements IConfiguration
     @Override
     public String getTribePreferredClusterIdOnConflict() {
         return TRIBE_PREFERRED_CLUSTER_ID_ON_CONFLICT.get();
+    }
+
+    @Override
+    public String getEsNodeName() {
+        return ES_NODE_NAME;
     }
 
 }

--- a/raigad/src/main/java/com/netflix/raigad/defaultimpl/StandardTuner.java
+++ b/raigad/src/main/java/com/netflix/raigad/defaultimpl/StandardTuner.java
@@ -52,7 +52,7 @@ public class StandardTuner implements IElasticsearchTuner
         File yamlFile = new File(yamlLocation);
         Map map = (Map) yaml.load(new FileInputStream(yamlFile));
         map.put("cluster.name", config.getAppName());
-        map.put("node.name", config.getRac() + "." + config.getInstanceId());
+        map.put("node.name", config.getEsNodeName());
         map.put("http.port", config.getHttpPort());
         map.put("path.data", config.getDataFileLocation());
         map.put("path.logs", config.getLogFileLocation());

--- a/raigad/src/main/java/com/netflix/raigad/utils/ESTransportClient.java
+++ b/raigad/src/main/java/com/netflix/raigad/utils/ESTransportClient.java
@@ -52,7 +52,7 @@ public class ESTransportClient
      * 
      * This will work only if Elasticsearch runs.
      */
-    public ESTransportClient(String host, int port, String clusterName) throws IOException, InterruptedException
+    public ESTransportClient(String host, int port, String clusterName, String nodeName) throws IOException, InterruptedException
     {
         Settings settings = ImmutableSettings.settingsBuilder().put("cluster.name", clusterName)
                 .put("client.transport.sniff", true)
@@ -60,13 +60,13 @@ public class ESTransportClient
         client = new TransportClient(settings);
         client.addTransportAddress(new InetSocketTransportAddress(host,port));
 
-        ndStatsRequestBuilder = client.admin().cluster().prepareNodesStats("_local").all();
+        ndStatsRequestBuilder = client.admin().cluster().prepareNodesStats(nodeName).all();
     }
 
     @Inject
     public ESTransportClient(IConfiguration config) throws IOException, InterruptedException
     {
-        this("localhost", config.getTransportTcpPort(), config.getAppName());
+        this("localhost", config.getTransportTcpPort(), config.getAppName(), config.getEsNodeName());
     }
 
     /**
@@ -112,7 +112,7 @@ public class ESTransportClient
 							@Override
 							public ESTransportClient retriableCall() throws Exception
 							{
-								ESTransportClient esTransportClientLocal = new ESTransportClient("localhost", config.getTransportTcpPort(),config.getAppName());
+								ESTransportClient esTransportClientLocal = new ESTransportClient("localhost", config.getTransportTcpPort(),config.getAppName(),config.getEsNodeName());
 						   		return esTransportClientLocal;
 							}
 						}.call();

--- a/raigad/src/test/java/com/netflix/raigad/configuration/FakeConfiguration.java
+++ b/raigad/src/test/java/com/netflix/raigad/configuration/FakeConfiguration.java
@@ -469,4 +469,9 @@ public class FakeConfiguration implements IConfiguration {
         return null;
     }
 
+    @Override
+    public String getEsNodeName() {
+        return null;
+    }
+
 }


### PR DESCRIPTION
Added new interface method to get EsNodeName.

Updated ESTransportClient by providing explicit Node Name