### PR TITLE
Adding VPC related changes for Security Groups

### DIFF
--- a/raigad/src/main/java/com/netflix/raigad/aws/AWSMembership.java
+++ b/raigad/src/main/java/com/netflix/raigad/aws/AWSMembership.java
@@ -170,7 +170,7 @@ public class AWSMembership implements IMembership
                 {
                     if (perm.getFromPort() == from && perm.getToPort() == to)
                     {
-                   		ipPermissions.addAll(perm.getIpRanges());
+                        ipPermissions.addAll(perm.getIpRanges());
                     }
                 }
             }
@@ -194,7 +194,9 @@ public class AWSMembership implements IMembership
             client = getEc2Client();
             List<IpPermission> ipPermissions = new ArrayList<IpPermission>();
             ipPermissions.add(new IpPermission().withFromPort(from).withIpProtocol("tcp").withIpRanges(listIPs).withToPort(to));
-            client.authorizeSecurityGroupIngress(new AuthorizeSecurityGroupIngressRequest(config.getACLGroupNameForVPC(), ipPermissions));
+            if (config.getACLGroupIdForVPC().isEmpty())
+                throw new RuntimeException("ACLGroupIdForVPC can NOT be empty, Check if SetVPCSecurityGroupID is throwing any error !!");
+            client.authorizeSecurityGroupIngress(new AuthorizeSecurityGroupIngressRequest().withGroupId(config.getACLGroupIdForVPC()).withIpPermissions(ipPermissions));
             logger.info("Done adding VPC ACL to: " + StringUtils.join(listIPs, ","));
         }
         finally
@@ -215,7 +217,9 @@ public class AWSMembership implements IMembership
             client = getEc2Client();
             List<IpPermission> ipPermissions = new ArrayList<IpPermission>();
             ipPermissions.add(new IpPermission().withFromPort(from).withIpProtocol("tcp").withIpRanges(listIPs).withToPort(to));
-            client.revokeSecurityGroupIngress(new RevokeSecurityGroupIngressRequest(config.getACLGroupNameForVPC(), ipPermissions));
+            if (config.getACLGroupIdForVPC().isEmpty())
+                throw new RuntimeException("ACLGroupIdForVPC can NOT be empty, Check if SetVPCSecurityGroupID is throwing any error !!");
+            client.revokeSecurityGroupIngress(new RevokeSecurityGroupIngressRequest().withGroupId(config.getACLGroupIdForVPC()).withIpPermissions(ipPermissions));
             logger.info("Done removing from VPC ACL: " + StringUtils.join(listIPs, ","));
         }
         finally
@@ -235,7 +239,9 @@ public class AWSMembership implements IMembership
         {
             client = getEc2Client();
             List<String> ipPermissions = new ArrayList<String>();
-            DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest().withGroupNames(Arrays.asList(config.getACLGroupNameForVPC()));
+            if (config.getACLGroupIdForVPC().isEmpty())
+                throw new RuntimeException("ACLGroupIdForVPC can NOT be empty, Check if SetVPCSecurityGroupID is throwing any error !!");
+            DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest().withGroupIds(config.getACLGroupIdForVPC());
             DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
             for (SecurityGroup group : result.getSecurityGroups())
             {

--- a/raigad/src/main/java/com/netflix/raigad/aws/SetVPCSecurityGroupID.java
+++ b/raigad/src/main/java/com/netflix/raigad/aws/SetVPCSecurityGroupID.java
@@ -1,0 +1,93 @@
+package com.netflix.raigad.aws;
+
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.DescribeSecurityGroupsRequest;
+import com.amazonaws.services.ec2.model.DescribeSecurityGroupsResult;
+import com.amazonaws.services.ec2.model.SecurityGroup;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.netflix.raigad.configuration.IConfiguration;
+import com.netflix.raigad.utils.SystemUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by sloke on 11/16/15.
+ * This class has been added especially for VPC Purposes.
+ * If SecurityGroup is deployed in VPC,
+ * then SecurityGroupId is needed to make any modifications or querying to associated SecurityGroup
+ *
+ * Sets the Security Group Id for the VPC Security Group
+ * If SecurityGroupId is not found for the matching the Security Group
+ * then RuntimeException is thrown
+ * */
+
+@Singleton
+public class SetVPCSecurityGroupID
+{
+    private static final Logger logger = LoggerFactory.getLogger(SetVPCSecurityGroupID.class);
+    private final IConfiguration config;
+    private final ICredential provider;
+
+    @Inject
+    public SetVPCSecurityGroupID(IConfiguration config, ICredential provider)
+    {
+        this.config = config;
+        this.provider = provider;
+    }
+
+    public void execute()
+    {
+        AmazonEC2 client = null;
+        try
+        {
+            client = getEc2Client();
+
+            //Get All the Existing Sec Group Ids
+            String[] sec_group_idarr = SystemUtils.getSecurityGroupIds(config.getMacIdForInstance());
+
+            boolean correctSecGroupFound = false;
+
+            for (String sec_grp_id : sec_group_idarr) {
+
+                logger.info("*** " + sec_grp_id);
+                DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest().withGroupIds(sec_grp_id);
+                DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
+
+                for (SecurityGroup secGroup : result.getSecurityGroups()) {
+                    logger.info("*** " + secGroup.getGroupName());
+                    if (secGroup.getGroupName().equals(config.getACLGroupNameForVPC())) {
+                        logger.info("@@@ SecGroupName = " + secGroup.getGroupName() + " matches for given Security Group Id = " + sec_grp_id);
+                        correctSecGroupFound = true;
+                        //Set the configuration value with Correct Security Group Id
+                        config.setACLGroupIdForVPC(sec_grp_id);
+                        break;
+                    }
+                }
+
+                if (correctSecGroupFound)
+                    break;
+            }
+            //If Correct Sec Group is NOT FOUND then throw Exception
+            if (!correctSecGroupFound)
+                throw new RuntimeException("Sec Group ID and Sec Group Name does NOT match, Something is Wrong, hence failing !!");
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+        finally
+        {
+            if (client != null)
+                client.shutdown();
+        }
+    }
+
+    private AmazonEC2 getEc2Client()
+    {
+        AmazonEC2 client = new AmazonEC2Client(provider.getAwsCredentialProvider());
+        client.setEndpoint("ec2." + config.getDC() + ".amazonaws.com");
+        return client;
+    }
+}

--- a/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/IConfiguration.java
@@ -315,4 +315,19 @@ public interface IConfiguration
      */
     public String getACLGroupNameForVPC();
 
+    /**
+     * Get the security group id for given Security Group in VPC
+     */
+    public String getACLGroupIdForVPC();
+
+    /**
+     * Set the security group id for given Security Group in VPC
+     */
+    public void setACLGroupIdForVPC(String aclGroupIdForVPC);
+
+    /**
+     * Get the MAC id for an instance
+     */
+    public String getMacIdForInstance();
+
 }

--- a/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
+++ b/raigad/src/main/java/com/netflix/raigad/configuration/RaigadConfiguration.java
@@ -127,7 +127,7 @@ public class RaigadConfiguration implements IConfiguration
     private static final String MAC_ID = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/mac");
     private static String VPC_ID = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/network/interfaces/macs/"+MAC_ID+"/vpc-id").trim();
 
-    private static String PUBLIC_HOSTNAME, PUBLIC_IP;
+    private static String PUBLIC_HOSTNAME, PUBLIC_IP, ACL_GROUP_ID_FOR_VPC;
 
     {
         if (VPC_ID.equals(SystemUtils.NOT_FOUND_STR)) {
@@ -372,7 +372,7 @@ public class RaigadConfiguration implements IConfiguration
             return null;
         }
     }
-    
+
     private class GetASGName extends RetryableCallable<String>
     {
         private static final int NUMBER_OF_RETRIES = 15;
@@ -905,5 +905,20 @@ public class RaigadConfiguration implements IConfiguration
     public String getACLGroupNameForVPC()
     {
         return ACL_GROUP_NAME_FOR_VPC.get();
+    }
+
+    @Override
+    public String getACLGroupIdForVPC() {
+        return ACL_GROUP_ID_FOR_VPC;
+    }
+
+    @Override
+    public void setACLGroupIdForVPC(String aclGroupIdForVPC) {
+        ACL_GROUP_ID_FOR_VPC =  aclGroupIdForVPC;
+    }
+
+    @Override
+    public String getMacIdForInstance() {
+        return MAC_ID;
     }
 }

--- a/raigad/src/main/java/com/netflix/raigad/startup/RaigadServer.java
+++ b/raigad/src/main/java/com/netflix/raigad/startup/RaigadServer.java
@@ -17,6 +17,7 @@ package com.netflix.raigad.startup;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.netflix.raigad.aws.SetVPCSecurityGroupID;
 import com.netflix.raigad.aws.UpdateSecuritySettings;
 import com.netflix.raigad.aws.UpdateTribeSecuritySettings;
 import com.netflix.raigad.aws.UpdateVPCSecuritySettings;
@@ -50,6 +51,7 @@ public class RaigadServer
     private final ElasticSearchIndexManager esIndexManager;
     private final SnapshotBackupManager snapshotBackupManager;
     private final HttpModule httpModule;
+    private final SetVPCSecurityGroupID setVPCSecurityGroupID;
     private static final int ES_MONITORING_INITIAL_DELAY = 10;
     private static final int ES_SNAPSHOT_INITIAL_DELAY = 100;
     private static final int ES_HEALTH_MONITOR_DELAY = 600;
@@ -61,7 +63,8 @@ public class RaigadServer
     public RaigadServer(IConfiguration config, RaigadScheduler scheduler, HttpModule httpModule, IElasticsearchProcess esProcess, Sleeper sleeper,
                         InstanceManager instanceManager,
                         ElasticSearchIndexManager esIndexManager,
-                        SnapshotBackupManager snapshotBackupManager)
+                        SnapshotBackupManager snapshotBackupManager,
+                        SetVPCSecurityGroupID setVPCSecurityGroupID)
     {
         this.config = config;
         this.scheduler = scheduler;
@@ -71,6 +74,7 @@ public class RaigadServer
         this.instanceManager = instanceManager;
         this.esIndexManager = esIndexManager;
         this.snapshotBackupManager = snapshotBackupManager;
+        this.setVPCSecurityGroupID = setVPCSecurityGroupID;
     }
 
     public void initialize() throws Exception
@@ -106,6 +110,8 @@ public class RaigadServer
                                 sleeper.sleep(60 * 1000);
                             scheduler.addTask(UpdateSecuritySettings.JOBNAME, UpdateSecuritySettings.class, UpdateSecuritySettings.getTimer(instanceManager));
                         }
+                        //Set SecurityGroupId
+                        setVPCSecurityGroupID.execute();
                         // update security settings
                         scheduler.runTaskNow(UpdateVPCSecuritySettings.class);
                         // sleep for 60 sec for the SG update to happen.

--- a/raigad/src/main/java/com/netflix/raigad/utils/SystemUtils.java
+++ b/raigad/src/main/java/com/netflix/raigad/utils/SystemUtils.java
@@ -304,4 +304,11 @@ public class SystemUtils
         return dateTime.toString(fmt);
     }
 
+    public static String[] getSecurityGroupIds(String MAC_ID)
+    {
+        String sec_group_ids = SystemUtils.getDataFromUrl("http://169.254.169.254/latest/meta-data/network/interfaces/macs/" + MAC_ID + "/security-group-ids/").trim();
+        if (sec_group_ids.isEmpty())
+            throw new RuntimeException("Security Group IDs are Null or Empty, Something is Wrong, hence failing !!");
+        return sec_group_ids.split("\n");
+    }
 }

--- a/raigad/src/test/java/com/netflix/raigad/configuration/FakeConfiguration.java
+++ b/raigad/src/test/java/com/netflix/raigad/configuration/FakeConfiguration.java
@@ -489,4 +489,19 @@ public class FakeConfiguration implements IConfiguration {
         return null;
     }
 
+    @Override
+    public String getACLGroupIdForVPC() {
+        return null;
+    }
+
+    @Override
+    public void setACLGroupIdForVPC(String aclGroupIdForVPC) {
+
+    }
+
+    @Override
+    public String getMacIdForInstance() {
+        return null;
+    }
+
 }


### PR DESCRIPTION
In VPC, SecurityGroupId is needed instead of SecurityGroupName for any modification or querying of Security Groups.

Hence added new changes to Set and access SecurityGroupId for VPC instance